### PR TITLE
fix: displaying of sun when night mode is activated

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,29 +1,28 @@
-import React, { useContext } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
 
-import logo from '../assets/images/logo.png';
+import logo from "../assets/images/logo.png";
 
-import { LocalContext } from '../wrappers/LocalContext';
+import { LocalContext } from "../wrappers/LocalContext";
 
 export default function Navbar() {
   const { darkTheme, changeTheme } = useContext(LocalContext);
-
   const history = useHistory();
 
   return (
     <div
       className={`w-full fixed h-20 px-2 lg:px-4 z-50 ${
-        !darkTheme ? 'bg-gray-100' : 'bg-gray-900'
+        !darkTheme ? "bg-gray-100" : "bg-gray-900"
       } py-2 duration-500 ease-in-out border-b-2 border-purple-500 flex items-center justify-between`}
     >
       <button
         className="flex items-center justify-between h-full"
-        onClick={() => history.push('/')}
+        onClick={() => history.push("/")}
       >
         <img src={logo} alt="konnect-logo" className="object-contain h-full" />
         <div
           className={`${
-            !darkTheme ? 'text-gray-900' : 'text-gray-100'
+            !darkTheme ? "text-gray-900" : "text-gray-100"
           } font-bold font-spartan ml-2 text-2xl pt-1`}
         >
           Snippets
@@ -37,9 +36,9 @@ export default function Navbar() {
       >
         <i
           className={`w-full h-full flex items-center justify-center text-xl ri-${
-            !darkTheme ? 'sun' : 'moon'
+            !darkTheme ? "moon" : "sun"
           }-fill ${
-            !darkTheme ? 'text-gray-700' : 'text-gray-300'
+            !darkTheme ? "text-gray-700" : "text-gray-300"
           } duration-500 ease-in-out`}
         />
       </button>


### PR DESCRIPTION
Usually the best practice is to display the moon when light mode is activated, so user can click on the moon and switch to dark mode and vice versa.

Implemented that.